### PR TITLE
Enable support for accessing SnarkVM synthesizer via WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,11 +2521,13 @@ name = "snarkvm-wasm"
 version = "0.9.11"
 dependencies = [
  "getrandom",
+ "paste",
  "rand",
  "serde",
  "snarkvm-console",
  "snarkvm-curves",
  "snarkvm-fields",
+ "snarkvm-synthesizer",
  "snarkvm-utilities",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -45,6 +45,7 @@ aleo-cli = [ ]
 cuda = [ "snarkvm-algorithms/cuda" ]
 setup = [ ]
 timer = [ "aleo-std/timer" ]
+wasm = [ ]
 
 [dependencies.circuit]
 package = "snarkvm-circuit"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -44,6 +44,13 @@ version = "0.9.11"
 optional = true
 default-features = false
 
+[dependencies.snarkvm-synthesizer]
+path = "../synthesizer"
+version = "0.9.11"
+features = [ "wasm" ]
+optional = true
+default-features = false
+
 [dependencies.snarkvm-utilities]
 path = "../utilities"
 version = "0.9.11"
@@ -72,13 +79,15 @@ version = "0.3.33"
 
 [features]
 default = [ "full", "parallel" ]
-full = [ "console", "curves", "fields", "utilities" ]
+full = [ "console", "curves", "fields", "synthesizer", "utilities" ]
 parallel = [
   "snarkvm-console/parallel",
   "snarkvm-fields/parallel",
+  "snarkvm-synthesizer/parallel",
   "snarkvm-utilities/parallel"
 ]
 console = [ "snarkvm-console" ]
 curves = [ "snarkvm-curves" ]
 fields = [ "snarkvm-fields" ]
+synthesizer = [ "snarkvm-synthesizer" ]
 utilities = [ "snarkvm-utilities" ]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -26,5 +26,8 @@ pub use snarkvm_fields::*;
 #[cfg(feature = "utilities")]
 pub use snarkvm_utilities::*;
 
+#[cfg(feature = "synthesizer")]
+pub use snarkvm_synthesizer::*;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Motivation

Several useful types needed for creating transaction within web clients via WASM exist in the SnarkVM-Synthesizer crate. However a blocking call from reqwests prevents it from successfully importing. 

Also, currently from a WASM context, because WASM does not support blocking, it's extremely hard to call external js networking functions in the middle of synchronous code. The inclusion proof creation currently either relies on a datastore or networking calls in the middle of synchronous contexts providing no easy way to provide the necessary data needed to complete the inclusion proofs from outside WASM library callers. This PR enables a pathway to create inclusion proofs by passing data in from environments which call WASM.

## Changelog
* Creates a "wasm" feature on the synthesizer crate 
* Conditional compilation is used to disable the reqwest::blocking call and provide ability to pass in inclusion proof data from outside contexts
* The SnarkVM-Wasm crate is updated to export SnarkVM-synthesizer functionality

## Test Plan
* Wasm unit tests
* Unit tests without a wasm build target to ensure nothing is broken in the original code

## Related PRs

